### PR TITLE
Lualatex info

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,4 +4,8 @@ The document can be generated using the following command:
 
 latexmk -pdf -silent cplexts
 
+Note: On some systems (Mac), the previous comment will invoke pdflatex,
+which does not work for this document.  In this case, one needs to
+invoke lualatex directly.
+
 Users of Windows should see WINDOWS.txt.

--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,8 @@ The document can be generated using the following command:
 latexmk -pdf -silent cplexts
 
 Note: On some systems (Mac), the previous comment will invoke pdflatex,
-which does not work for this document.  In this case, one needs to
-invoke lualatex directly.
+which does not work for this document.  In this case, build with this command:
+
+latexmk -pdf -lualatex -silent cplexts
 
 Users of Windows should see WINDOWS.txt.


### PR DESCRIPTION
This adds the documentation necessary for a user to figure out how to build on Mac, or some other system where latexmk defaults to pdflatex, which does not work.
